### PR TITLE
(relating to js.swc) Return type with template should be treated as *

### DIFF
--- a/compiler.jx/src/org/apache/flex/compiler/internal/codegen/externals/utils/FunctionUtils.java
+++ b/compiler.jx/src/org/apache/flex/compiler/internal/codegen/externals/utils/FunctionUtils.java
@@ -63,7 +63,7 @@ public class FunctionUtils
         {
             returnType = JSTypeUtils.toReturnTypeString(reference);
             if (containsTemplate(reference, returnType))
-            	returnType = "Object";
+            	returnType = "*";
             else if (returnType.equals("RESULT"))
             	returnType = "Object";
         }


### PR DESCRIPTION
The code "var x:int = [1,2].pop();" should not generate an error "Implicit coercion of a value with static type Object to a possibly unrelated type int."